### PR TITLE
refactoring getUserLogin to provide also promises

### DIFF
--- a/src/user/user.ts
+++ b/src/user/user.ts
@@ -1,3 +1,6 @@
+
+declare var Promise: any;
+
 export default
 class User {
     constructor(private db:any, private LISTS:any, private VIEWS:any) {
@@ -51,8 +54,20 @@ class User {
      * @param userId:string
      * @param callback
      */
-    getUserLogin = (userId:string, callback) => {
-        this.db.view(this.VIEWS.USER_LOGIN, {key: userId}, callback);
+    getUserLogin = (userId:string, callback = (e, r) => {}) => {
+        var promise = new Promise((resolve, reject) => {
+            this.db.list(this.LISTS.LIST_USER_LOGIN, {key: userId}, (err, result) => {
+                callback(err, result[0]);
+
+                // reject also if there is no match in the database
+                if(err || !result[0]) {
+                    return reject(err);
+                }
+                resolve(result[0]);
+            });
+        });
+
+        return promise;
     };
 
     /**


### PR DESCRIPTION
This solution still allows us to use "standard callbacks".
If we'd say we quit using callbacks the code would look something like this:

``` javascript
getUserLogin = (userId:string) => {
    return new Promise((resolve, reject) => {
        this.db.list(this.LISTS.LIST_USER_LOGIN, {key: userId}, (err, result) => {
            if(err || !result[0]) {
                return reject(err);
            }
            resolve(result[0]);
        });
    });
};
```
